### PR TITLE
Fix typo in resources page

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -133,7 +133,7 @@
                     <span>★ ★ ★ ☆ ☆ (3.0)</span>
                 </li>
             </ul>
-        </li>y
+        </li>
         
         <!-- External Calculators -->
         <li>


### PR DESCRIPTION
## Summary
- remove stray `y` character in Author-Built Calculators list

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e061dd0808321a29d6e7cb785f4b4